### PR TITLE
ENH: Use gramener.com base when un-currentScript-able #33

### DIFF
--- a/src/comicgen.js
+++ b/src/comicgen.js
@@ -109,7 +109,7 @@ function create_parametric_svg(node, sliderVal) {
 //  https://cdn.jsdelivr.net/npm/comicgen         -> https://cdn.jsdelivr.net/npm/comicgen/
 //  node_modules/comicgen/dist/comicgen.min.js    -> node_modules/comicgen/
 // Handle all scenarios and get the base location
-comicgen.base = (document.currentScript.src + '/').replace(/[a-z]*\/[a-z.]*\.js\/$/, '')
+comicgen.base = ((document.currentScript || {src: 'https://gramener.com/comicgen'}).src + '/').replace(/[a-z]*\/[a-z.]*\.js\/$/, '')
 
 // Import comicgen version from package.json
 comicgen.version = version


### PR DESCRIPTION
In certain runtimes we can't use `document.currentScript.src` .  This changes uses https://gramener.com/comicgen.

See #33 for usage.

This doesn't fully solve the issue. But works for my need (observablehq runtime). 

Would like a minor release if possible.